### PR TITLE
[202012] CPU Usage Spike Issue Handled

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -224,7 +224,7 @@ def init_mgmt_interface_tables(db_conn):
     if_alias_map = dict()
 
     for if_name in oid_name_map.values():
-        if_entry = db_conn.get_all(CONFIG_DB, mgmt_if_entry_table(if_name), blocking=True)
+        if_entry = db_conn.get_all(CONFIG_DB, mgmt_if_entry_table(if_name), blocking=False)
         if_alias_map[if_name] = if_entry.get('alias', if_name)
 
     logger.debug("Management alias map:\n" + pprint.pformat(if_alias_map, indent=2))
@@ -283,7 +283,7 @@ def init_sync_d_interface_tables(db_conn):
     if_alias_map = dict()
 
     for if_name in if_name_map:
-        if_entry = db_conn.get_all(APPL_DB, if_entry_table(if_name), blocking=True)
+        if_entry = db_conn.get_all(APPL_DB, if_entry_table(if_name), blocking=False)
         if_alias_map[if_name] = if_entry.get('alias', if_name)
 
     logger.debug("Chassis name map:\n" + pprint.pformat(if_alias_map, indent=2))
@@ -353,7 +353,7 @@ def init_sync_d_queue_tables(db_conn):
 
     # { Port name : Queue index (SONiC) -> sai_id }
     # ex: { "Ethernet0:2" : "1000000000023" }
-    queue_name_map = db_conn.get_all(COUNTERS_DB, COUNTERS_QUEUE_NAME_MAP, blocking=True)
+    queue_name_map = db_conn.get_all(COUNTERS_DB, COUNTERS_QUEUE_NAME_MAP, blocking=False)
     logger.debug("Queue name map:\n" + pprint.pformat(queue_name_map, indent=2))
 
     # Parse the queue_name_map and create the following maps:

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -200,7 +200,7 @@ class LocPortUpdater(MIBUpdater):
         else:
             return None
 
-        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=True)
+        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
 
     def update_interface_data(self, if_name):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -150,7 +150,7 @@ class NextHopUpdater(MIBUpdater):
             ipnstr = routestr[len("ROUTE_TABLE:"):]
             if ipnstr == "0.0.0.0/0":
                 ipn = ipaddress.ip_network(ipnstr)
-                ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, routestr, blocking=True)
+                ent = Namespace.dbs_get_all(self.db_conn, mibs.APPL_DB, routestr, blocking=False)
                 nexthops = ent["nexthop"]
                 for nh in nexthops.split(','):
                     # TODO: if ipn contains IP range, create more sub_id here
@@ -229,7 +229,7 @@ class InterfacesUpdater(MIBUpdater):
             namespace, sai_id = mibs.split_sai_id_key(sai_id_key)
             if_idx = mibs.get_index_from_str(self.if_id_map[sai_id_key])
             self.if_counters[if_idx] = self.namespace_db_map[namespace].get_all(mibs.COUNTERS_DB, \
-                    mibs.counter_table(sai_id), blocking=True)
+                    mibs.counter_table(sai_id), blocking=False)
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \
@@ -357,7 +357,7 @@ class InterfacesUpdater(MIBUpdater):
         else:
             return None
 
-        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=True)
+        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
 
     def _get_if_entry_state_db(self, sub_id):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -102,7 +102,7 @@ class InterfaceMIBUpdater(MIBUpdater):
             namespace, sai_id = mibs.split_sai_id_key(sai_id_key)
             if_idx = mibs.get_index_from_str(self.if_id_map[sai_id_key])
             self.if_counters[if_idx] = self.namespace_db_map[namespace].get_all(mibs.COUNTERS_DB, \
-                    mibs.counter_table(sai_id), blocking=True)
+                    mibs.counter_table(sai_id), blocking=False)
 
     def get_next(self, sub_id):
         """
@@ -222,7 +222,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         else:
             return None
 
-        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=True)
+        return Namespace.dbs_get_all(self.db_conn, db, if_table, blocking=False)
 
     def get_high_speed(self, sub_id):
         """

--- a/src/sonic_ax_impl/mibs/ietf/rfc4363.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4363.py
@@ -79,7 +79,7 @@ class FdbUpdater(MIBUpdater):
                 mibs.logger.error("SyncD 'ASIC_DB' includes invalid FDB_ENTRY '{}': {}.".format(fdb_str, e))
                 continue
 
-            ent = Namespace.dbs_get_all(self.db_conn, mibs.ASIC_DB, s, blocking=True)
+            ent = Namespace.dbs_get_all(self.db_conn, mibs.ASIC_DB, s, blocking=False)
             # Example output: oid:0x3a000000000608
             bridge_port_id = ent["SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID"][6:]
             if bridge_port_id not in self.if_bpid_map:

--- a/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
+++ b/src/sonic_ax_impl/mibs/vendor/cisco/ciscoPfcExtMIB.py
@@ -48,7 +48,7 @@ class PfcUpdater(MIBUpdater):
             namespace, sai_id = mibs.split_sai_id_key(sai_id_key)
             if_idx = mibs.get_index_from_str(self.if_id_map[sai_id_key])
             self.if_counters[if_idx] = self.namespace_db_map[namespace].get_all(mibs.COUNTERS_DB, \
-                    mibs.counter_table(sai_id), blocking=True)
+                    mibs.counter_table(sai_id), blocking=False)
 
         self.lag_name_if_name_map, \
         self.if_name_lag_name_map, \


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

Verified on the Version which has this commit: sonic-swss/pull/1804

```
admin@sonic:~$ show ver

SONiC Software Version: SONiC.202012.130-8acb20677_Internal
Distribution: Debian 10.10
Kernel: 4.19.0-12-2-amd64
Build commit: 8acb20677
Build date: Fri Jul 16 12:54:07 UTC 2021
Built by: sw-r2d2-bot@r-build-sonic-ci03

Platform: x86_64-mlnx_msn4700-r0
HwSKU: ACS-MSN4700
ASIC: mellanox
ASIC Count: 1
Serial Number: MT2047X05586
Uptime: 07:27:34 up  7:01,  1 user,  load average: 0.42, 0.25, 0.20

admin@sonic:~$ counterpoll show
Type                        Interval (in ms)    Status
--------------------------  ------------------  --------
QUEUE_STAT                  default (10000)     disable
PORT_STAT                   default (1000)      disable
PORT_BUFFER_DROP            default (60000)     disable
RIF_STAT                    default (1000)      disable
QUEUE_WATERMARK_STAT        default (10000)     disable
PG_WATERMARK_STAT           default (10000)     disable
PG_DROP_STAT                default (10000)     disable
BUFFER_POOL_WATERMARK_STAT  default (10000)     disable

CPU Usage is normal:

CONTAINER ID        NAME                CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O           PIDS
12db43f74d75        snmp                2.28%               61.24MiB / 15.56GiB   0.38%               0B / 0B             61.4kB / 81.9kB     9
b58649fdaf02        telemetry           1.17%               144.4MiB / 15.56GiB   0.91%               0B / 0B             36.6MB / 86kB       35
abecc451239e        mgmt-framework      0.03%               112.2MiB / 15.56GiB   0.70%               0B / 0B             26.3MB / 69.6kB     19
f39a4a650d43        radv                0.03%               30.09MiB / 15.56GiB   0.19%               0B / 0B             225kB / 77.8kB      6
c58d55ed4e56        lldp                0.04%               54.94MiB / 15.56GiB   0.34%               0B / 0B             6MB / 115kB         11
a7ff6a4e6a51        pmon                37.54%              240.9MiB / 15.56GiB   1.51%               0B / 0B             58.3MB / 6.04MB     17
dc4269cbd26f        dhcp_relay          0.03%               30.65MiB / 15.56GiB   0.19%               0B / 0B             459kB / 73.7kB      6
7d277afdcea1        syncd               0.69%               845MiB / 15.56GiB     5.30%               0B / 0B             39.5MB / 69.6kB     39
b99396746503        teamd               0.06%               34.18MiB / 15.56GiB   0.21%               0B / 0B             3.94MB / 90.1kB     12
632b5e536707        swss                0.15%               47.45MiB / 15.56GiB   0.30%               0B / 0B             15.6MB / 229kB      33
8aa0943e0e64        bgp                 0.05%               71.56MiB / 15.56GiB   0.45%               0B / 0B             16.6MB / 19.4MB     22
12f178550f94        restapi             0.04%               40.02MiB / 15.56GiB   0.25%               0B / 0B             34.8MB / 102kB      8
261eca81d21d        database            1.30%               59.57MiB / 15.56GiB   0.37%               0B / 0B             38.7MB / 65.5kB     11
```


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

